### PR TITLE
[GO-LIVE-FIXES] Determine Delivery Date by Time Zone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "cmdk": "^0.2.0",
         "embla-carousel-react": "^8.0.0-rc19",
         "lucide-react": "^0.302.0",
+        "luxon": "^3.4.4",
         "next": "14.0.4",
         "react": "^18",
         "react-dom": "^18",
@@ -46,6 +47,7 @@
       },
       "devDependencies": {
         "@tanstack/eslint-plugin-query": "^5.14.6",
+        "@types/luxon": "^3.4.0",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -2147,6 +2149,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.0.tgz",
+      "integrity": "sha512-PEVoA4MOfSsFNaPrZjIUGUZujBDxnO/tj2A2N9KfzlR+pNgpBdDuk0TmRvSMAVUP5q4q8IkMEZ8UOp3MIr+QgA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -5242,6 +5250,14 @@
       "integrity": "sha512-JZX+1fjpqxvQmEgItvPOAwRlqf0Eg9dSZMxljA2/V2M6dluOhQCPBhewIlSJWgkNu0M36kViOgmTAMnDaAMOFw==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cmdk": "^0.2.0",
     "embla-carousel-react": "^8.0.0-rc19",
     "lucide-react": "^0.302.0",
+    "luxon": "^3.4.4",
     "next": "14.0.4",
     "react": "^18",
     "react-dom": "^18",
@@ -47,6 +48,7 @@
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.14.6",
+    "@types/luxon": "^3.4.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/components/PDP/CarSelector.tsx
+++ b/src/components/PDP/CarSelector.tsx
@@ -57,6 +57,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '../ui/accordion';
+import DeliveryDate from './components/DeliveryDate';
 
 const ProductVideo = dynamic(() => import('./ProductVideo'), { ssr: false });
 
@@ -87,10 +88,10 @@ function CarSelector({
         product.year_generation === pathParams.product[2]
     );
 
-  console.log(initialProduct);
+  // console.log(initialProduct);
 
   const displays = modelData.map((model) => model.display_color);
-  console.log('displays', displays);
+  // console.log('displays', displays);
 
   const [selectedProduct, setSelectedProduct] = useState<TProductData>(
     initialProduct ?? modelData[0]
@@ -108,8 +109,8 @@ function CarSelector({
     : pathParams?.product?.length === 3;
 
   const shouldSubmodelDisplay = !!submodels.length && !searchParams?.submodel;
-  console.log('shouldSubmodelDisplay', shouldSubmodelDisplay);
-  console.log(modelData.filter((product) => product.sku.includes('100983')));
+  // console.log('shouldSubmodelDisplay', shouldSubmodelDisplay);
+  // console.log(modelData.filter((product) => product.sku.includes('100983')));
 
   const uniqueColors = Array.from(
     new Set(modelData.map((model) => model.display_color))
@@ -118,8 +119,8 @@ function CarSelector({
   const uniqueTypes = Array.from(
     new Set(modelData.map((model) => model.display_id))
   ).map((type) => modelData.find((model) => model.display_id === type));
-  console.log('uniqueCoverColors', uniqueColors);
-  console.log('uniqueCoverTypes', uniqueTypes);
+  // console.log('uniqueCoverColors', uniqueColors);
+  // console.log('uniqueCoverTypes', uniqueTypes);
 
   const handleAddToCart = () => {
     if (!selectedProduct) return;
@@ -132,7 +133,7 @@ function CarSelector({
     selectedProduct?.product
       ?.split(',')
       .filter((img) => img !== featuredImage) ?? [];
-  console.log('productImages', productImages);
+  //console.log('productImages', productImages);
   const modalProductImages = productImages.slice(5);
   const reviewScore = reviewData?.reduce(
     (acc, review) => acc + Number(review.rating_stars ?? 0),
@@ -142,9 +143,9 @@ function CarSelector({
 
   const avgReviewScore = (reviewScore / reviewCount).toFixed(1);
 
-  console.log(avgReviewScore);
-  console.log(searchParams?.submodel);
-  console.log(selectedProduct);
+  //console.log(avgReviewScore);
+  //console.log(searchParams?.submodel);
+  //console.log(selectedProduct);
 
   return (
     <section className="h-auto w-full max-w-[1440px] mx-auto my-8">
@@ -432,9 +433,7 @@ function CarSelector({
                   </span>
                   <br className="xl:hidden" />
                   <span className="hidden xl:block md:mr-1">-</span>
-                  <span className="font-normal">
-                    Delivery by <span className="uppercase">oct18</span>
-                  </span>
+                  <DeliveryDate />
                 </div>
                 <p className="text-dark text-sm">
                   Order within{' '}

--- a/src/components/PDP/components/DeliveryDate.tsx
+++ b/src/components/PDP/components/DeliveryDate.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { DateTime } from 'luxon';
+import { useMounted } from '@/components/hooks/useMount';
+
+const getClientTimeZone = (): string => {
+  const timeZoneOffset: number = new Date().getTimezoneOffset();
+  // Timezone offset in minutes for PST, MST, CST, EST
+  const PST: number = 480; // UTC -8
+  const MST: number = 420; // UTC -7
+  const CST: number = 360; // UTC -6
+  const EST: number = 300; // UTC -5
+
+  // Converting the offset to the string commonly returned by Intl.DateTimeFormat().resolvedOptions().timeZone
+  if (timeZoneOffset === PST) {
+    return 'America/Los_Angeles';
+  } else if (timeZoneOffset === MST) {
+    return 'America/Denver';
+  } else if (timeZoneOffset === CST) {
+    return 'America/Chicago';
+  } else if (timeZoneOffset === EST) {
+    return 'America/New_York';
+  } else {
+    return 'Unknown';
+  }
+};
+
+/**
+ * Determines the delivery by date.
+ * Current logic is for PST, before 2 PM, delivery date will be 2 days later.
+ * If after 2 PM, add another day.
+ * For MST, it will be 3 days later. For CST, 4 days later. For EST, 5 days later.
+ * Currently don't know what to do for other time zones and defaulting to 5 days later.
+ * @returns string
+ */
+const determineDeliveryByDate = (): string => {
+  const clientTimeZone: string = getClientTimeZone();
+  const now: DateTime = DateTime.now().setZone(clientTimeZone);
+  let daysToAdd: number;
+
+  switch (clientTimeZone) {
+    case 'America/Los_Angeles': // PST
+      daysToAdd = 2;
+      break;
+    case 'America/Denver': // MST
+      daysToAdd = 3;
+      break;
+    case 'America/Chicago': // CST
+      daysToAdd = 4;
+      break;
+    case 'America/New_York': // EST
+      daysToAdd = 5;
+      break;
+    case 'Unknown':
+      daysToAdd = 5;
+      break;
+    default:
+      daysToAdd = 0; // Adjusted if needed
+  }
+
+  // If it's after 2 PM, add an extra day
+  if (now.hour >= 14) {
+    daysToAdd += 1;
+  }
+
+  const deliveryDate: DateTime = now.plus({ days: daysToAdd });
+
+  return deliveryDate.toFormat('LLL dd');
+};
+
+export default function DeliveryDate(): JSX.Element {
+  const isMounted = useMounted();
+  return isMounted ? (
+    <span className="font-normal">
+      Delivery by <span className="uppercase">{determineDeliveryByDate()}</span>
+    </span>
+  ) : (
+    <span className="font-normal">Loading...</span>
+  );
+}

--- a/src/components/hooks/useMount.tsx
+++ b/src/components/hooks/useMount.tsx
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+export const useMounted = (): boolean => {
+  const [mounted, setMounted] = useState<boolean>(false);
+  // effects run only client-side
+  // so we can detect when the component is hydrated/mounted
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted;
+};


### PR DESCRIPTION
# Description

Made an update to the PDP page where delivery date is determined based on client's time zone.

**Fixes # (issue)**: Skype Request:

> Delivery by OCT 18 - PST time zone: Before 2 PM, show delivery as 2 days later (e.g., if today is JAN 11, it should display JAN 13). After 2 PM, the date should change to JAN 14.
> 
> MST time zone: Show delivery as 1 extra day later than PST. Display JAN 14 before 2 PM and JAN 15 after 2 PM.
> 
> CST time zone: Show delivery as 1 extra day later than MST. Display JAN 15 before 2 PM and JAN 16 after 2 PM.
> 
> EST time zone: Show delivery as 1 extra day later than CST. Display JAN 16 before 2 PM and JAN 17 after 2 PM.
> 
> 
> If this task takes some time, you can simply display the delivery date as 2 days from today, which is JAN 13, before 2 PM, and 3 days after 2 PM, which would be JAN 14.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Describe your changes

- Added new component `DeliveryDate`
- Added luxon 
- Used luxon to determine client time zone & then determine number of days to add get delivery date
- Added a useEffect hook to determine if component is mounted to avoid hydration problems

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

To test time zone:
- Pull down branch
- Change your local time on the computer
- Refresh the page and verify

To test the hour:
- Add this to `determineDeliveryByDate`: ` const updatedDateTime = now.set({ hour: 14 });`
- Update the `now.hour >= 14` to `updatedDateTime.now >= 14`
- (or just change the original `now` to `old_now` and do `const now = old_now.set({ hour: 14 });`
- Refresh the page and verify the date

## Test Cases

- [x]  PST: Jan 14/Jan 15
- [x]  MST: Jan 15/Jan 16
- [x]  CST: Jan 16/Jan 17 
- [x]  EST: Jan 17/Jan 18

# Checklist:
(we can change this in the future I guess) 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked for mobile and desktop responsiveness

