### PR TITLE
[PDP] Updated SubmodelSearch and Submodel2Search and Titles for Submodel2

### DIFF
--- a/src/components/PDP/CarSelector.tsx
+++ b/src/components/PDP/CarSelector.tsx
@@ -279,23 +279,16 @@ function CarSelector({
 
   const avgReviewScore = (reviewScore / reviewCount).toFixed(1);
 
-  //console.log(isFullySelected, isReadyForSelection);
-
-  //console.log(submodels, secondSubmodels);
-
-  //// console.log(avgReviewScore);
-  // console.log(searchParams?.submodel);
-  // console.log(selectedProduct);
+  const fullProductName = `${selectedProduct?.year_generation}
+  ${selectedProduct?.make} ${selectedProduct?.product_name} 
+  ${searchParams?.submodel ? selectedProduct?.submodel1 : ''}
+  ${searchParams?.second_submodel ? selectedProduct?.submodel2 : ''}
+  `;
 
   return (
     <section className="mx-auto h-auto w-full max-w-[1440px] px-4 lg:my-8">
       <div className="flex w-full flex-col items-start justify-between lg:flex-row lg:gap-14">
-        {isMobile && (
-          <EditVehiclePopover
-            selectedProduct={selectedProduct}
-            submodel={searchParams?.submodel}
-          />
-        )}
+        {isMobile && <EditVehiclePopover fullProductName={fullProductName} />}
         {/* Left Panel */}
         <div className=" -ml-4 mt-[29px] flex h-auto w-screen flex-col items-stretch justify-center pb-2 lg:w-3/5 lg:pb-0 ">
           {/* Featured Image */}
@@ -362,10 +355,7 @@ function CarSelector({
         <div className=" h-auto w-full pl-0 lg:w-2/5">
           <div className=" mt-[29px] hidden flex-col gap-2 rounded-lg border-2 border-solid px-3 py-7 lg:flex">
             <h2 className="font-roboto text-lg font-extrabold text-[#1A1A1A] md:text-[28px]">
-              {`${selectedProduct?.year_generation}
-                ${selectedProduct?.make} ${selectedProduct?.product_name} ${
-                  searchParams?.submodel ? selectedProduct?.submodel1 : ''
-                }`}
+              {fullProductName}
             </h2>
             <div className="flex items-center gap-2">
               <EditIcon />

--- a/src/components/PDP/CarSelector.tsx
+++ b/src/components/PDP/CarSelector.tsx
@@ -91,6 +91,10 @@ const EditVehicleDropdown = dynamicImport(
 
 export const dynamic = 'force-dynamic';
 
+interface ProductRefs {
+  [key: string]: RefObject<HTMLElement>;
+}
+
 function TimeTo2PMPST() {
   const [timeRemaining, setTimeRemaining] = useState(calculateTimeTo2PM()); // Set initial value
 
@@ -153,12 +157,6 @@ function CarSelector({
   reviewData: TReviewData[];
   parentGeneration: any;
 }) {
-  //console.log(
-  //   modelData.map((model) => model.submodel2),
-  //   'huh'
-  // );
-
-  //console.log(secondSubmodels);
   const defaultModel = modelData.find(
     (model) =>
       model.fk ===
@@ -173,26 +171,23 @@ function CarSelector({
     ) ?? [];
 
   const modelsBySecondSubmodel = searchParams?.second_submodel
-    ? modelData.filter(
-        (model) =>
-          stringToSlug(model?.submodel2 as string) ===
-          stringToSlug(searchParams?.second_submodel as string)
-      ) ?? modelsBySubmodel
+    ? modelData
+        .filter(
+          (model) =>
+            stringToSlug(model?.submodel1 as string) ===
+            stringToSlug(searchParams?.submodel as string)
+        )
+        .filter(
+          (model) =>
+            stringToSlug(model?.submodel2 as string) ===
+            stringToSlug(searchParams?.second_submodel as string)
+        ) ?? modelsBySubmodel
     : modelsBySubmodel;
-
-  //console.log(modelsBySubmodel);
-
-  //console.log(
-  //   stringToSlug(modelData[4]?.submodel1 as string),
-  //   searchParams.submodel
-  // );
 
   const isFullySelected =
     pathParams?.product?.length === 3 &&
     (submodels.length === 0 || !!searchParams?.submodel) &&
     (secondSubmodels.length === 0 || !!searchParams?.second_submodel);
-
-  //console.log(modelData);
 
   let displayedModelData = searchParams?.submodel
     ? modelsBySubmodel
@@ -203,34 +198,19 @@ function CarSelector({
     : displayedModelData;
 
   const [selectedProduct, setSelectedProduct] = useState<TProductData>(
-    isFullySelected
+    isFullySelected || searchParams?.submodel
       ? displayedModelData[0]
       : defaultModel ?? displayedModelData[0]
   );
+
   const [featuredImage, setFeaturedImage] = useState<string>(
     selectedProduct?.feature as string
   );
-  //console.log(submodels, secondSubmodels, defaultModel);
+
   const router = useRouter();
   const path = usePathname();
 
   const { cartItems, cartOpen, setCartOpen } = useCartContext();
-
-  // function removeBeforeCom(url: string) {
-  //   const pos = url?.indexOf('.com');
-
-  //   if (pos === -1) {
-  //     return url;
-  //   }
-  //   return url?.substring(pos + 4);
-  // }
-
-  interface ProductRefs {
-    [key: string]: RefObject<HTMLElement>;
-  }
-
-  //console.log(modelData);
-  //console.log(selectedProduct);
 
   const productRefs = useRef<ProductRefs>(
     displayedModelData.reduce((acc: ProductRefs, item: TProductData) => {
@@ -253,8 +233,6 @@ function CarSelector({
   ).map((color) =>
     displayedModelData.find((model) => model.display_color === color)
   );
-
-  //console.log(uniqueColors);
 
   const uniqueTypes = Array.from(
     new Set(displayedModelData.map((model) => model.display_id))
@@ -628,7 +606,7 @@ function CarSelector({
               <>
                 <Popover>
                   <PopoverTrigger asChild>
-                    <Button className="mt-4 h-[35px] w-full rounded bg-[#BE1B1B] text-lg font-bold uppercase text-white md:h-[60px] md:text-xl">
+                    <Button className="mt-4 h-[48px] w-full bg-[#BE1B1B] text-lg font-bold uppercase text-white disabled:bg-[#BE1B1B] md:h-[62px] md:text-xl">
                       Add To Cart
                     </Button>
                   </PopoverTrigger>
@@ -641,7 +619,7 @@ function CarSelector({
               </>
             ) : (
               <Button
-                className="mt-4 h-[60px] w-full bg-[#BE1B1B] text-lg disabled:bg-[#BE1B1B]"
+                className="mt-4 h-[48px] w-full bg-[#BE1B1B] text-lg font-bold uppercase text-white disabled:bg-[#BE1B1B] md:h-[62px] md:text-xl"
                 onClick={() => {
                   track('PDP_add_to_cart', {
                     sku: selectedProduct?.sku,

--- a/src/components/PDP/CarSelector.tsx
+++ b/src/components/PDP/CarSelector.tsx
@@ -203,12 +203,22 @@ function CarSelector({
       : defaultModel ?? displayedModelData[0]
   );
 
+  const router = useRouter();
+  const path = usePathname();
+
+  // Sometimes when submodel2 is selected, selectedProduct won't update to the right one
+  useEffect(() => {
+    const updateSelectedProduct = () => {
+      setSelectedProduct(displayedModelData[0]);
+    };
+    if (isFullySelected) {
+      updateSelectedProduct();
+    }
+  }, [searchParams, isFullySelected, displayedModelData]);
+
   const [featuredImage, setFeaturedImage] = useState<string>(
     selectedProduct?.feature as string
   );
-
-  const router = useRouter();
-  const path = usePathname();
 
   const { cartItems, cartOpen, setCartOpen } = useCartContext();
 

--- a/src/components/PDP/components/EditVehiclePopover.tsx
+++ b/src/components/PDP/components/EditVehiclePopover.tsx
@@ -16,19 +16,14 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 export default function EditVehiclePopover({
-  selectedProduct,
-  submodel,
+  fullProductName,
 }: {
-  selectedProduct: TProductData;
-  submodel: string | undefined;
+  fullProductName: string;
 }) {
   return (
     <div className=" z-50 flex flex-col gap-2">
       <h2 className="font-roboto text-2xl font-extrabold text-[#1A1A1A]">
-        {`${selectedProduct?.year_generation}
-                        ${selectedProduct?.make} ${
-                          selectedProduct?.product_name
-                        } ${submodel ? selectedProduct?.submodel1 : ''}`}
+        {fullProductName}
       </h2>
       <div className="z-50 flex items-center gap-2">
         <EditIcon />

--- a/src/components/PDP/components/SubDropdowns.tsx
+++ b/src/components/PDP/components/SubDropdowns.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { TProductData } from '@/lib/db';
 import { track } from '@vercel/analytics';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import useCarSelection from '@/lib/db/hooks/useCarSelection';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
@@ -72,13 +72,6 @@ export default function SubDropdowns({
       slugify(car?.model) === (pathname?.split('/')[3] as string)
   );
 
-  const availableSecondSubmodels = Array.from(
-    new Set(modelsWithSubmodel.map((car) => car?.submodel2))
-  );
-
-  //console.log(selectedSubmodel);
-  //console.log(availableSecondSubmodels);
-
   const setSearchParams = () => {
     let url: string = '';
 
@@ -96,8 +89,6 @@ export default function SubDropdowns({
     router.push(`?${url}`);
     // refreshRoute(`${pathname}?${currentParams.toString()}`);
   };
-
-  //console.log(!!submodels.length, !submodelParam);
 
   const hasSubmodel = new Set(modelData.map((car) => car?.submodel1)).size > 1;
   const hasSecondSubModel =
@@ -132,7 +123,7 @@ export default function SubDropdowns({
               modelData={modelData}
               setSelectedSecondSubmodel={setSelectedSecondSubmodel}
               submodelParam2nd={submodelParam2nd}
-              secondSubmodels={availableSecondSubmodels as string[]}
+              selectedSubmodel={selectedSubmodel}
             />
           )}
         </div>

--- a/src/components/PDP/components/SubmodelSearch.tsx
+++ b/src/components/PDP/components/SubmodelSearch.tsx
@@ -34,8 +34,6 @@ export function SubmodelSearch({
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  //console.log(searchParams);
-
   // Get a new searchParams string by merging the current
   // searchParams with a provided key/value pair
   const createQueryString = useCallback(
@@ -67,18 +65,12 @@ export function SubmodelSearch({
   );
 
   const { uniqueSubmodel1 } = extractUniqueValues(modelData as TProductData[]);
-  //console.log(shouldTriggerSetParams);
 
   const uniqueSubmodelsFromModelData = Array.from(
     new Set(
       modelData.map((row) => row.submodel1).filter((model) => Boolean(model))
     )
   );
-  //console.log(value);
-  // const submodelParam = searchParams?.get('submodel') ?? '';
-  //console.log(submodelParam);
-
-  //console.log(submodels, uniqueSubmodelsFromModelData);
 
   // Need to trigger when value is updated and shouldTriggerSetParams is set to
   // true so handleSubmitDropdown will trigger
@@ -102,15 +94,17 @@ export function SubmodelSearch({
 
   return (
     <select
-      value={value}
+      value={value.toLowerCase()}
+      defaultValue={value.toLowerCase() ?? ''}
       onChange={handleChange}
       className="rounded-lg px-2 py-3 text-lg"
     >
-      <option value={submodelParam ?? ''}>
-        {submodelParam ? deslugify(submodelParam) : 'Select car submodel'}
-      </option>
+      <option value={''}>{'Select car submodel'}</option>
       {uniqueSubmodelsFromModelData?.sort()?.map((submodel) => (
-        <option key={`model-${submodel}`} value={submodel as string}>
+        <option
+          key={`model-${submodel}`}
+          value={submodel?.toLowerCase() as string}
+        >
           {deslugify(submodel)}
         </option>
       ))}

--- a/src/components/PDP/components/SubmodelSearch2nd.tsx
+++ b/src/components/PDP/components/SubmodelSearch2nd.tsx
@@ -66,7 +66,8 @@ export function SubmodelSearch2nd({
     setValue(newValue);
     setSelectedSecondSubmodel(newValue);
   };
-
+  console.log('2ndSearch availableSecondSubmodels:', availableSecondSubmodels);
+  console.log('2ndSearch value:', value);
   return (
     <select
       value={value}

--- a/src/components/PDP/components/SubmodelSearch2nd.tsx
+++ b/src/components/PDP/components/SubmodelSearch2nd.tsx
@@ -6,42 +6,43 @@ import {
   Dispatch,
   SetStateAction,
   useCallback,
+  useEffect,
   useState,
 } from 'react';
-import { extractUniqueValues } from '../utils';
-import { Button } from '@/components/ui/button';
-import { Check, ChevronDown } from 'lucide-react';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-} from '@/components/ui/command';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
-import { cn } from '@/lib/utils';
-import { usePathname, useSearchParams } from 'next/navigation';
-import { useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 
 export function SubmodelSearch2nd({
   setSelectedSecondSubmodel,
   modelData,
   submodelParam2nd,
-  secondSubmodels,
+  selectedSubmodel,
 }: {
   modelData: TProductData[];
   setSelectedSecondSubmodel: Dispatch<SetStateAction<string | null>>;
   submodelParam2nd: string | null;
-  secondSubmodels: string[];
+  selectedSubmodel: string | null;
 }) {
   const [value, setValue] = useState(() => submodelParam2nd ?? '');
-  const pathname = usePathname();
-  const router = useRouter();
   const searchParams = useSearchParams();
+  const [availableSecondSubmodels, setAvailableSecondSubmodels] = useState<
+    string[]
+  >([]);
+
+  // Updates the second submodel based on when first submodel is selected
+  useEffect(() => {
+    const secondSubmodelData: string[] = Array.from(
+      new Set(
+        modelData
+          .filter((d) => d.submodel1 === selectedSubmodel)
+          .map((d) => d.submodel2)
+          .filter((submodel) => submodel !== null && submodel !== undefined)
+          .map((submodel) => submodel as string)
+      )
+    );
+    if (selectedSubmodel) {
+      setAvailableSecondSubmodels(secondSubmodelData);
+    }
+  }, [selectedSubmodel, modelData]);
 
   // Get a new searchParams string by merging the current
   // searchParams with a provided key/value pair
@@ -53,9 +54,6 @@ export function SubmodelSearch2nd({
       return params.toString();
     },
     [searchParams]
-  );
-  const secondSubmodelData = Array.from(
-    new Set(modelData.map((d) => d.submodel2))
   );
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
@@ -71,7 +69,7 @@ export function SubmodelSearch2nd({
       className="my-2 rounded-lg px-2 py-3 text-lg"
     >
       <option value="">Select your secondary submodel</option>
-      {secondSubmodelData?.sort()?.map((submodel) => (
+      {availableSecondSubmodels?.sort()?.map((submodel) => (
         <option key={`model-${submodel}`} value={submodel ?? ''}>
           {submodel}
         </option>

--- a/src/components/PDP/components/SubmodelSearch2nd.tsx
+++ b/src/components/PDP/components/SubmodelSearch2nd.tsx
@@ -29,11 +29,16 @@ export function SubmodelSearch2nd({
   >([]);
 
   // Updates the second submodel based on when first submodel is selected
+  // Checking for lower case because if only submodel is in search params, it'll pass down
+  // as string to slug (lower case) but submodel is Camel Cased
   useEffect(() => {
     const secondSubmodelData: string[] = Array.from(
       new Set(
         modelData
-          .filter((d) => d.submodel1 === selectedSubmodel)
+          .filter(
+            (d) =>
+              d.submodel1?.toLowerCase() === selectedSubmodel?.toLowerCase()
+          )
           .map((d) => d.submodel2)
           .filter((submodel) => submodel !== null && submodel !== undefined)
           .map((submodel) => submodel as string)


### PR DESCRIPTION
- Had issue where if you had submodel and submodel2, title wasn't reflected properly
- Select your vehicle had issues selecting properly
- Submodel2 wasn't being filtered properly based on submodel1
- Now filters submodel2 based on submodel1 selection
- Fixed default value when only submodel1 was picked and submodel2 is needed
- Now shows full product name

Test cases:
Test going to PDP w/o selecting submodel
Test selecting the submodel first and then the second submodel on the PDP page.
Test selecting both on the PDP page.

Test different combinations of these and other trucks and regular cars with submodels
- truck-covers/gmc/sierra-1500/2014-2018?&submodel=crew+cab&second_submodel=5.5+ft.+short+bed
- truck-covers/gmc/sierra-1500/2014-2018?&submodel=crew+cab&second_submodel=6.5+ft.+regular+bed
- /car-covers/mercedes/240d/1977-1985?submodel=sedan&second_submodel=non-us+version
