### PR TITLE
Hotfix for hero dropdown (car selection)

### DIFF
--- a/src/app/(main)/car-covers/[make]/[model]/[year]/page.tsx
+++ b/src/app/(main)/car-covers/[make]/[model]/[year]/page.tsx
@@ -1,5 +1,5 @@
 import { slugify } from '@/lib/utils';
-import generationData from '@/data/generationData.json';
+import generationData from '@/data/staticGenerationTableData.json';
 import {
   TReviewData,
   fetchCarPDPData,
@@ -21,6 +21,17 @@ export type TCarCoverSlugParams = {
   };
 };
 
+export type TGenerationData = {
+  fk: number;
+  generation_default: number;
+  year_generation: string;
+  make: string;
+  model: string;
+  submodel1: string | null;
+  submodel2: string | null;
+  year_options: string;
+}[];
+
 export default async function CarPDPDataLayer({
   params,
 }: {
@@ -31,9 +42,16 @@ export default async function CarPDPDataLayer({
       slugify(gen.make) === params.make &&
       slugify(gen.model) === params.model &&
       gen.year_generation === params.year
-  )[0]?.generation;
+  )[0]?.generation_default;
 
-  const modelData: TCarCoverData[] | null = await fetchCarPDPData(generationFk);
+  const availableGenerations = generationData.filter(
+    (gen) => gen.generation_default === generationFk || gen.fk === generationFk
+  );
+
+  const modelData: TCarCoverData[] | null = await fetchCarPDPData(
+    generationFk,
+    availableGenerations
+  );
 
   if (!modelData) {
     redirect('/404');

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -7,6 +7,7 @@ import {
 import { deslugify } from '../utils';
 import { refreshRoute } from '@/app/(main)/[productType]/[...product]/actions';
 import { TCarCoverData } from '@/app/(main)/car-covers/components/CarPDP';
+import { TGenerationData } from '@/app/(main)/car-covers/[make]/[model]/[year]/page';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY ?? '';
@@ -112,12 +113,19 @@ export async function fetchPDPData(
 }
 
 export async function fetchCarPDPData(
-  generationFk: number
+  generationFk: number,
+  availableGenerations: TGenerationData
 ): Promise<TCarCoverData[] | null> {
-  const { data, error } = await supabase
-    .from('product_2024_join')
-    .select('*')
-    .eq('generation_default', generationFk);
+  let fetch = supabase.from('product_2024_join').select('*');
+
+  console.log(availableGenerations.length);
+  if (availableGenerations.length > 1) {
+    fetch = fetch.eq('generation_default', generationFk);
+  } else {
+    fetch = fetch.eq('fk', generationFk);
+  }
+
+  const { data, error } = await fetch;
 
   if (error) {
     console.log(error);


### PR DESCRIPTION
- Addressed edgecase where generation is it's own parent generation (e.g. cars that only display one type of car in one year generation, with no other submodels)