### PR TITLE
[CK-Request] Updated text to always show cover color even when submodel not selected

### DIFF
--- a/src/app/(main)/car-covers/components/CarCoverSelector.tsx
+++ b/src/app/(main)/car-covers/components/CarCoverSelector.tsx
@@ -142,12 +142,9 @@ export function CarCoverSelector({
             submodelParam={submodelParam}
           />
           <p className="ml-3 mt-2 text-lg font-black text-[#1A1A1A] ">
-            {isReadyForProductSelection
-              ? `Cover Colors`
-              : `Please select your car's details below`}{' '}
+            Cover Colors
             <span className="ml-2 text-lg font-normal text-[#767676]">
-              {isReadyForProductSelection &&
-                `${selectedProduct?.display_color}`}
+              {selectedProduct?.display_color}
             </span>
           </p>
           <ColorSelector

--- a/src/components/PDP/CarSelector.tsx
+++ b/src/components/PDP/CarSelector.tsx
@@ -347,11 +347,9 @@ function CarSelector({
             </div>
           </div>
           <p className="ml-3 mt-2 text-lg font-black text-[#1A1A1A] ">
-            {isReadyForSelection
-              ? `Cover Colors`
-              : `Please select your car's details below`}{' '}
+            Cover Colors
             <span className="ml-2 text-lg font-normal text-[#767676]">
-              {isReadyForSelection && `${selectedProduct?.display_color}`}
+              {selectedProduct?.display_color}
             </span>
           </p>
           <div className="flex flex-row space-x-1 overflow-x-auto whitespace-nowrap p-2 lg:grid lg:w-auto lg:grid-cols-5 lg:gap-[7px] lg:px-3">

--- a/src/components/PDP/CarSelector.tsx
+++ b/src/components/PDP/CarSelector.tsx
@@ -220,10 +220,6 @@ function CarSelector({
   const [showMore, setShowMore] = useState(false);
   const isMobile = useMediaQuery('(max-width: 768px)');
 
-  const isReadyForSelection = submodels.length
-    ? pathParams?.product?.length === 3 && !!searchParams?.submodel
-    : pathParams?.product?.length === 3;
-
   const uniqueColors = Array.from(
     new Set(displayedModelData.map((model) => model.display_color))
   ).map((color) =>


### PR DESCRIPTION
- When a car has a submodel but it's not selected, it said to "Please finish your selection" 
- Calvin didn't want it so took that out and it just says Cover Color now