### PR TITLE
[CK-Request] Home Page Fixes And Some

### DIFF
--- a/src/app/(main)/car-covers/components/PartialCoverSelector.tsx
+++ b/src/app/(main)/car-covers/components/PartialCoverSelector.tsx
@@ -389,14 +389,6 @@ export function PartialCoverSelector({
             <div className="grid grid-cols-1">
               <p className="text-dark relative mb-2.5 text-xl font-bold capitalize md:text-3xl">
                 $159.95
-                <span className="top absolute ml-2.5 text-xl font-normal capitalize text-[#D13C3F]">
-                  only{' '}
-                  {`${Math.max(
-                    2,
-                    Math.min(7, Math.floor(reviewCount / 25) + 2)
-                  )}`}{' '}
-                  left
-                </span>
               </p>
               <p className="text-lg font-normal text-[#1A1A1A] md:text-[22px]">
                 <span className="mr-2 text-[#9C9C9C] line-through">$320</span>

--- a/src/app/(main)/policies/warranty-policy/page.tsx
+++ b/src/app/(main)/policies/warranty-policy/page.tsx
@@ -9,38 +9,35 @@ function WarrantyPolicy({ hideHeader }: { hideHeader?: boolean }) {
     <>
       {!hideHeader && <PolicyHeader headerText="Warranty" />}
       <div className="lg:mx-auto lg:flex lg:w-[842px] lg:flex-col lg:justify-center">
-        <div className="relative px-5 lg:py-14">
-          <PolicyTitle
-            title="Up to a 10-Year Comprehensive Warranty"
-            uppercase
-          />
+        <div className="relative px-5 pb-4 lg:py-14">
+          <PolicyTitle title="FULL WARRANTY FOR UP TO A LIFETIME!" uppercase />
           <PolicyTitle title="Welcome to Coverland's Warranty Page" uppercase />
           <PolicyDetail>
             At Coverland, we are committed to providing our customers with
             exceptional quality products and peace of mind. We stand behind the
-            craftsmanship and durability of our items with a comprehensive up to
-            a 10-year warranty.
+            craftsmanship and durability of our items, offering a comprehensive
+            warranty for up to a lifetime.
           </PolicyDetail>
           <PolicyTitle title="Warranty Coverage" uppercase />
           <PolicyDetail>
-            Our warranty provides coverage for a period of up to ten years,
-            depending on the specific warranty period of your product. It starts
-            from the date of purchase and includes protection against various
-            issues:
+            Our warranty covers your product for up to a lifetime, depending on
+            its specific warranty period, starting from the date of purchase. It
+            includes protection against various issues:
           </PolicyDetail>
           <ol className="list-disc pl-6 pt-4">
             <li>
-              <span className="font-bold">Normal Wear and Tear:</span> We
-              understand that regolar use over time can cause natural wear. Our
-              warranty ensures your product remains functional throughout its
-              lifespan.
+              <span className="font-bold">Normal Wear and Tear:</span> Whether
+              it&apos;s intense sun, heavy rain, snow, or hail, our products are
+              designed to withstand diverse weather conditions. If your product
+              fails to protect your vehicle due to weather-related damages,
+              we&apos;ve got you covered.
             </li>
             <li>
               <span className="font-bold">Weather-Related Damages:</span> Be it
               intense sun, heavy rain, snow, or hail, our products are designed
               to withstand diverse weather conditions. If your product fails to
-              protect your vehicle due to weather-related damages, we’ve got you
-              covered.
+              protect your vehicle due to weather-related damages, we&apos;ve
+              got you covered.
             </li>
             <li>
               <span className="font-bold">Ripping and Tears:</span> Despite the
@@ -85,9 +82,11 @@ function WarrantyPolicy({ hideHeader }: { hideHeader?: boolean }) {
           <PolicyDetail>
             At Coverland, your satisfaction is our priority. We strive to ensure
             every customer is confident in their purchase. This comprehensive
-            warranty is our promise of quality and reliability. Thank you for
-            choosing Coverland for your product needs. We value your trust and
-            look forward to serving you.
+            warranty is our promise of quality and reliability.
+          </PolicyDetail>
+          <PolicyDetail>
+            Thank you for choosing Coverland for your product needs. We value
+            your trust and look forward to serving you.
           </PolicyDetail>
           <div className="pt-5 lg:pt-12"></div>
           <PolicyFurtherAssistance />

--- a/src/components/PDP/CarSelector.tsx
+++ b/src/components/PDP/CarSelector.tsx
@@ -551,11 +551,12 @@ function CarSelector({
             <div className="grid grid-cols-1">
               <p className="text-dark relative mb-2.5 text-xl font-bold capitalize md:text-3xl">
                 ${selectedProduct?.msrp}
-                {selectedProduct?.display_id !== 'Premium' && (
-                  <span className="top absolute ml-2.5 text-xl font-normal capitalize text-[#D13C3F]">
-                    only {generateProductsLeft(selectedProduct)} left
-                  </span>
-                )}
+                {selectedProduct?.display_id !== 'Premium' &&
+                  isFullySelected && (
+                    <span className="top absolute ml-2.5 text-xl font-normal capitalize text-[#D13C3F]">
+                      only {generateProductsLeft(selectedProduct)} left
+                    </span>
+                  )}
               </p>
               {selectedProduct?.price && (
                 <p className="text-lg font-normal text-[#1A1A1A] md:text-[22px]">

--- a/src/components/PDP/MobilePDPAccordions.tsx
+++ b/src/components/PDP/MobilePDPAccordions.tsx
@@ -82,14 +82,14 @@ export function MobilePDPAccordions({
       <AccordionDrawerItem title="Warranty">
         <div className=" md:mt-18 mb-[-10px]  lg:mt-28">
           <div className="flex flex-col gap-5  normal-case">
-            <div className="flex text-[18px] font-black">10-Years Warranty</div>
+            <div className="flex text-[18px] font-black">Lifetime Warranty</div>
             <div className="mb-[-15px] text-[14px] font-[500]">
               Safeguard your valuable investment with the peace of mind that
               comes from our industry-leading
             </div>
             <div className="text-[14px] font-[500]">
               {
-                " 10-years car cover warranty. Your car deserves the best protection, and we're here to deliver it."
+                "Lifetime car cover warranty. Your car deserves the best protection, and we're here to deliver it."
               }
             </div>
           </div>

--- a/src/components/PDP/PDPAccordian.tsx
+++ b/src/components/PDP/PDPAccordian.tsx
@@ -13,74 +13,105 @@ export function PDPAccordion() {
         <h2 className="hidden text-center text-2xl font-black uppercase text-[#1A1A1A] md:text-3xl lg:text-5xl">
           q&a
         </h2>
-        <Accordion type="single" collapsible className="w-full">
-          <div className=" hidden h-[137px] w-full flex-col text-center text-[45px] font-black lg:flex ">
+        <Accordion type="single" collapsible className="w-full ">
+          <div className=" hidden h-[137px] w-full flex-col text-center text-[45px] font-black lg:flex  ">
             Q&A
           </div>
           <AccordionItem value="item-1">
-            <AccordionTrigger className="text-base font-black capitalize text-[#1A1A1A]  md:text-xl lg:py-8 lg:text-[28px]">
-              Is putting this car cover on a hassle ?
+            <AccordionTrigger className="text-left text-base font-black capitalize  text-[#1A1A1A] md:text-xl lg:py-8 lg:text-[28px]">
+              Why is this car cover a good choice?
             </AccordionTrigger>
             <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
-              We make buying the right cover simple and easy. Simply use our
-              cover finder tool on the homepage to find the exact custom-fit car
-              cover for your make and model. Once you insert the information,
-              you will be directed to a page where you can choose from 2
-              different options: standard versus premium. With over 120,000 car
-              covers available, we have the exact custom-fit, tailored car cover
-              for your vehicle, no matter the year, make, or model.
+              If you are looking for the best of the best on the market,
+              you&apos;ve found the right one. Engineered to fight off rain,
+              sun, and dust, it keeps your car in pristine condition for years.
+              It&apos;s a must-have for long-lasting car care protection.
             </AccordionContent>
           </AccordionItem>
           <AccordionItem value="item-2">
-            <AccordionTrigger className="py-4 text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
-              Guaranteed Durability & quality
+            <AccordionTrigger className="py-4 text-left text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
+              How many layers does your car cover have?
             </AccordionTrigger>
             <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
-              We make sure to guarantee your satisfaction with our exceptional
-              customer service. At the heart of our commitment lies a dedication
-              to understanding and fulfilling your needs with utmost precision
-              and care. Our team of friendly, knowledgeable professionals is
-              always ready to provide personalized assistance, ensuring a
-              seamless and enjoyable experience.
+              Our car cover features a cutting-edge single-layer design, free of
+              bonding welds, offering all the benefits of multilayered materials
+              without the drawbacks. This design forms a tight bond, eliminating
+              the risk of material separation and ensuring optimal performance.
             </AccordionContent>
           </AccordionItem>
           <AccordionItem value="item-3">
-            <AccordionTrigger className="py-4 text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
-              how to order Full custom car cover?
+            <AccordionTrigger className="py-4 text-left text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
+              What special features does this cover have?{' '}
             </AccordionTrigger>
             <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
-              We make sure to guarantee your satisfaction with our exceptional
-              customer service. At the heart of our commitment lies a dedication
-              to understanding and fulfilling your needs with utmost precision
-              and care. Our team of friendly, knowledgeable professionals is
-              always ready to provide personalized assistance, ensuring a
-              seamless and enjoyable experience.
+              Beyond weather protection, it also guards against bird droppings
+              and tree sap. Additionally, this car cover&apos;s design prevents
+              moisture buildup, ensuring top-tier care for your car.
             </AccordionContent>
           </AccordionItem>
           <AccordionItem value="item-4">
-            <AccordionTrigger className="py-4 text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
-              Car cover cleaning guide
+            <AccordionTrigger className="py-4 text-left text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
+              Will this fit my car?{' '}
             </AccordionTrigger>
             <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
-              We make sure to guarantee your satisfaction with our exceptional
-              customer service. At the heart of our commitment lies a dedication
-              to understanding and fulfilling your needs with utmost precision
-              and care. Our team of friendly, knowledgeable professionals is
-              always ready to provide personalized assistance, ensuring a
-              seamless and enjoyable experience.
+              Our car covers are specially designed for a precise fit, offering
+              ultimate protection for your vehicle.
             </AccordionContent>
           </AccordionItem>
           <AccordionItem value="item-5">
-            <AccordionTrigger className="py-4 text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
-              Exceptional Customer Service
+            <AccordionTrigger className="py-4 text-left text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
+              What if I&apos;m not happy with it?{' '}
             </AccordionTrigger>
             <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
-              We make sure to guarantee your satisfaction with our exceptional
-              customer service. At the heart of our commitment lies a dedication
-              to understanding and fulfilling your needs with utmost precision
-              and care. Our team of friendly, knowledgeable professionals is
-              always ready to provide personalized assistance, ensuring a
-              seamless and enjoyable experience.
+              No worries! We prioritize your happiness. If you&apos;re not
+              completely satisfied, you&apos;re covered by our free 30-day
+              return policy, along with a 60-day full money-back guarantee. Shop
+              with confidence!
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="item-6">
+            <AccordionTrigger className="py-4 text-left text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
+              Is it safe to leave my car covered outside in heavy rain?{' '}
+            </AccordionTrigger>
+            <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
+              Of course! You can leave your vehicle outdoors during heavy rain
+              with this cover on. Our unique car covers are built with
+              heavy-duty materials designed to protect your car from extreme and
+              harsh weather conditions, including rain, snow, hail, and storms.
+              The strong construction not only ensures all-weather protection
+              but also safeguards against abrasion, thanks to a soft cotton
+              inner lining.
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="item-7">
+            <AccordionTrigger className="py-4 text-left text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
+              Does this cover protect from the Sun?{' '}
+            </AccordionTrigger>
+            <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
+              Yes. This car cover guarantee to provide you with 100% protection
+              from the sun&apos;s heat and UV rays. We ensure that your
+              car&apos;s interior temperature is regulated while protecting the
+              exterior from any kind of damage.
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="item-8">
+            <AccordionTrigger className="py-4 text-left text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
+              Can I use your car cover on a windy day?{' '}
+            </AccordionTrigger>
+            <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
+              Yes, this car cover comes with three tie-down straps in the front,
+              middle, and back, preventing the car cover from blowing away, even
+              in winds of up to 50 mph.
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="item-9">
+            <AccordionTrigger className="py-4 text-left text-base font-black capitalize text-[#1A1A1A] md:py-6 md:text-xl lg:py-8 lg:text-[28px]">
+              When will I receive my order?{' '}
+            </AccordionTrigger>
+            <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
+              We offer same-day shipping with a cut-off time at 2 pm PST. Your
+              item will typically arrive within 1-5 business days after
+              shipment.
             </AccordionContent>
           </AccordionItem>
         </Accordion>

--- a/src/components/PDP/PDPAccordian.tsx
+++ b/src/components/PDP/PDPAccordian.tsx
@@ -88,7 +88,7 @@ export function PDPAccordion() {
               Does this cover protect from the Sun?{' '}
             </AccordionTrigger>
             <AccordionContent className="text-sm font-normal text-[#1A1A1A] md:text-lg">
-              Yes. This car cover guarantee to provide you with 100% protection
+              Yes. This car cover guarantees to provide you with 100% protection
               from the sun&apos;s heat and UV rays. We ensure that your
               car&apos;s interior temperature is regulated while protecting the
               exterior from any kind of damage.

--- a/src/components/PDP/components/WarrantyDesktop.tsx
+++ b/src/components/PDP/components/WarrantyDesktop.tsx
@@ -4,11 +4,11 @@ export function WarrantyDesktop() {
   return (
     <div className="px-[60px]">
       <div className=" flex w-full items-center gap-[92px] border border-gray-200 px-[40px] py-[93px] text-center">
-        {/* min-w-[449px] below to limit 10-year warranty length */}
-        <div className="w-6/12  text-[42px] font-black">10-YEARS WARRANTY</div>
+        {/* min-w-[449px] below to limit lifetime warranty length */}
+        <div className="w-6/12  text-[42px] font-black">LIFETIME WARRANTY</div>
         <div className="w-6/12 text-left text-[20px]">
           {
-            "Safeguard your valuable investment with the peace of mind that comes from our industry-leading 10-years car cover warranty. Your car deserves the best protection, and we're here to deliver it."
+            "Safeguard your valuable investment with the peace of mind that comes from our industry-leading lifetime car cover warranty. Your car deserves the best protection, and we're here to deliver it."
           }
         </div>
       </div>

--- a/src/components/hero/dropdown/MakeSearch.tsx
+++ b/src/components/hero/dropdown/MakeSearch.tsx
@@ -25,8 +25,9 @@ export function MakeSearch({
 
   return (
     <button
-      className={`flex max-h-[44px] md:max-h-[58px] outline-[#767676] min-h-[44px] w-full items-center rounded-[4px] ${!queryObj.query.year ? 'bg-gray-100/75' : 'bg-white'} px-2 text-lg outline outline-1 outline-offset-1 lg:w-auto`}
+      className={`flex max-h-[44px] min-h-[44px] w-full items-center rounded-[4px] outline-[#767676] md:max-h-[58px] ${!queryObj.query.year ? 'bg-gray-100/75' : 'bg-white'} px-2 text-lg outline outline-1 outline-offset-1 lg:w-auto`}
       disabled={!query.type || !query.year}
+      tabIndex={1}
     >
       <div className="ml-[10px] pr-[15px]">3</div>
       <select

--- a/src/components/hero/dropdown/ModelSearch.tsx
+++ b/src/components/hero/dropdown/ModelSearch.tsx
@@ -26,8 +26,9 @@ export function ModelSearch({
 
   return (
     <button
-      className={`flex max-h-[44px] md:max-h-[58px] outline-[#767676] min-h-[44px] w-full items-center rounded-[4px] outline outline-1 outline-offset-1 ${!queryObj.query.make ? 'bg-gray-100/75' : 'bg-white'} px-2 text-lg lg:w-auto`}
+      className={`flex max-h-[44px] min-h-[44px] w-full items-center rounded-[4px] outline outline-1 outline-offset-1 outline-[#767676] md:max-h-[58px] ${!queryObj.query.make ? 'bg-gray-100/75' : 'bg-white'} px-2 text-lg lg:w-auto`}
       disabled={isDisabled}
+      tabIndex={1}
     >
       <div className="ml-[10px] pr-[15px]">4</div>
       <select

--- a/src/components/hero/dropdown/SubmodelDropdown.tsx
+++ b/src/components/hero/dropdown/SubmodelDropdown.tsx
@@ -38,8 +38,9 @@ export function SubmodelDropdown({
 
   return (
     <button
-      className={`flex max-h-[44px] md:max-h-[58px] outline-[#767676] min-h-[44px] w-full items-center rounded-lg ${!queryObj.query.make ? 'bg-gray-100/75' : 'bg-white'} px-2 text-lg outline outline-1 outline-offset-1 lg:w-auto`}
+      className={`flex max-h-[44px] min-h-[44px] w-full items-center rounded-lg outline-[#767676] md:max-h-[58px] ${!queryObj.query.make ? 'bg-gray-100/75' : 'bg-white'} px-2 text-lg outline outline-1 outline-offset-1 lg:w-auto`}
       disabled={isDisabled}
+      tabIndex={1}
     >
       <div className="ml-[10px] pr-[15px]">5</div>
       <select

--- a/src/components/hero/dropdown/TypeSearch.tsx
+++ b/src/components/hero/dropdown/TypeSearch.tsx
@@ -24,8 +24,9 @@ export function TypeSearch({
 
   return (
     <button
-      className={`flex max-h-[44px] md:max-h-[58px] min-h-[44px] w-full items-center rounded-[4px] bg-white px-2 text-lg outline outline-1 outline-offset-1 outline-[#767676] lg:w-auto`}
+      className={`flex max-h-[44px] min-h-[44px] w-full items-center rounded-[4px] bg-white px-2 text-lg outline outline-1 outline-offset-1 outline-[#767676] md:max-h-[58px] lg:w-auto`}
       disabled={!queryObj.query.type}
+      tabIndex={1}
     >
       <div className=" ml-[10px] pr-[15px]">1</div>
       <select

--- a/src/components/hero/dropdown/YearSearch.tsx
+++ b/src/components/hero/dropdown/YearSearch.tsx
@@ -25,8 +25,9 @@ export function YearSearch({
 
   return (
     <button
-      className={`flex max-h-[44px] md:max-h-[58px] outline-[#767676] min-h-[44px] w-full items-center rounded-[4px]  ${!queryObj.query.type ? 'bg-gray-100/75' : 'bg-white'} px-2 text-lg outline outline-1 outline-offset-1 lg:w-auto`}
+      className={`flex max-h-[44px] min-h-[44px] w-full items-center rounded-[4px] outline-[#767676] md:max-h-[58px]  ${!queryObj.query.type ? 'bg-gray-100/75' : 'bg-white'} px-2 text-lg outline outline-1 outline-offset-1 lg:w-auto`}
       disabled={!queryObj.query.type}
+      tabIndex={1}
     >
       <div className="ml-[10px] pr-[15px]">2</div>
       <select

--- a/src/components/home/BestSellingSection.tsx
+++ b/src/components/home/BestSellingSection.tsx
@@ -10,7 +10,7 @@ const bestSelling = [
   { title: 'Dodge Challenger', img: Challenger },
   { title: 'Chevy Corvette', img: Corvette },
   { title: 'Mazda Miata', img: Miata },
-  { title: 'Chevy El-camino', img: ElCamino },
+  { title: 'Chevy El-Camino', img: ElCamino },
 ];
 const BestSellingSection = () => {
   return (
@@ -18,7 +18,7 @@ const BestSellingSection = () => {
       <p className="text-[20px] font-black lg:text-[32px]">
         BEST-SELLING CAR MODELS
       </p>
-      <div className="max-w-screen flex gap-[20px] overflow-x-auto">
+      <div className="max-w-screen flex gap-[20px] overflow-x-auto pb-3">
         {bestSelling.map(({ title, img }, i) => (
           <a
             key={`${title}-${i}`}
@@ -26,14 +26,12 @@ const BestSellingSection = () => {
             className="flex min-h-[209px] min-w-[209px] flex-[25%] flex-col items-center justify-between"
           >
             <Image alt="Best-Selling-Car-Cover" className="" src={img} />
-            <div className="flex flex-col">
-              <p className="mb-[18px] whitespace-nowrap text-[16px] font-[500] leading-[24px] lg:text-[22px]">
-                {title}
-              </p>
-              <button className="mb-[2px] flex h-[44px] max-w-[153px] items-center justify-center whitespace-nowrap rounded-[100px] px-[40px] py-[17px] text-[16px] font-[900] leading-[110%] tracking-[0.32px] outline outline-[1px]">
-                <div>Shop Now</div>
-              </button>
-            </div>
+            <p className="mb-[18px] whitespace-nowrap text-[16px] font-[500] leading-[24px] lg:text-[22px]">
+              {title}
+            </p>
+            <button className="mb-[2px] flex h-[44px] max-w-[153px] items-center justify-center whitespace-nowrap rounded-[100px] px-[40px] py-[17px] text-[16px] font-[900] leading-[110%] tracking-[0.32px] outline outline-[1px]">
+              <div>Shop Now</div>
+            </button>
           </a>
         ))}
       </div>

--- a/src/components/home/BestSellingSection.tsx
+++ b/src/components/home/BestSellingSection.tsx
@@ -6,7 +6,7 @@ import Miata from '@/images/hero/best-selling-miata.png';
 import Corvette from '@/images/hero/best-selling-corvette.png';
 import Image from 'next/image';
 
-const BestSelling = [
+const bestSelling = [
   { title: 'Dodge Challenger', img: Challenger },
   { title: 'Chevy Corvette', img: Corvette },
   { title: 'Mazda Miata', img: Miata },
@@ -19,9 +19,10 @@ const BestSellingSection = () => {
         BEST-SELLING CAR MODELS
       </p>
       <div className="max-w-screen flex gap-[20px] overflow-x-auto">
-        {BestSelling.map(({ title, img }) => (
-          <div
-            key={``}
+        {bestSelling.map(({ title, img }, i) => (
+          <a
+            key={`${title}-${i}`}
+            href="/car-covers"
             className="flex min-h-[209px] min-w-[209px] flex-[25%] flex-col items-center justify-between"
           >
             <Image alt="Best-Selling-Car-Cover" className="" src={img} />
@@ -30,10 +31,10 @@ const BestSellingSection = () => {
                 {title}
               </p>
               <button className="mb-[2px] flex h-[44px] max-w-[153px] items-center justify-center whitespace-nowrap rounded-[100px] px-[40px] py-[17px] text-[16px] font-[900] leading-[110%] tracking-[0.32px] outline outline-[1px]">
-                <a href="/car-covers">Shop Now</a>
+                <div>Shop Now</div>
               </button>
             </div>
-          </div>
+          </a>
         ))}
       </div>
     </span>

--- a/src/components/home/CoversGrid.tsx
+++ b/src/components/home/CoversGrid.tsx
@@ -4,7 +4,6 @@ import CAR from '@/images/hero/car-cover-home-icon.png';
 import TRUCK from '@/images/hero/truck-cover-home-icon.png';
 import SUV from '@/images/hero/suv-cover-home-icon.png';
 
-
 const coverTypes = [
   { title: 'Car Covers', img: CAR },
   { title: 'Truck Covers', img: TRUCK },
@@ -16,9 +15,12 @@ const CoversGrid = () => {
     <span className="mt-[-70px] h-full flex-col items-center px-4 lg:flex lg:px-[80px]">
       <div className="grid h-full max-w-[1280px]  grid-cols-2 grid-rows-2 place-items-center gap-[7px] lg:gap-[20px]  ">
         {coverTypes.map(({ title, img }) => (
-          <div key={`${title}-block`}>
+          <div
+            key={`${title}-block`}
+            className={`${title !== 'Car Covers' ? 'pointer-events-none' : ''}`}
+          >
             <a
-              href="/car-covers"
+              href={'/car-covers'}
               className="flex min-w-[167px]  flex-col items-center justify-center rounded-[8px] p-[10px] shadow-md lg:flex-row lg:gap-[36px] lg:px-[50px]"
             >
               <p className="order-last flex min-w-[45%] flex-[0.1] justify-center whitespace-nowrap text-center align-middle text-[14px] font-[900] uppercase lg:order-first lg:w-1/2 lg:max-w-[45%] lg:text-[24px]">

--- a/src/components/home/CoversGrid.tsx
+++ b/src/components/home/CoversGrid.tsx
@@ -14,9 +14,9 @@ const CoversGrid = () => {
   return (
     <span className="mt-[-70px] h-full flex-col items-center px-4 lg:flex lg:px-[80px]">
       <div className="grid h-full max-w-[1280px]  grid-cols-2 grid-rows-2 place-items-center gap-[7px] lg:gap-[20px]  ">
-        {coverTypes.map(({ title, img }) => (
+        {coverTypes.map(({ title, img }, i) => (
           <div
-            key={`${title}-block`}
+            key={`${title}-${i}-block`}
             className={`${title !== 'Car Covers' ? 'pointer-events-none' : ''}`}
           >
             <a

--- a/src/components/home/TrendingCarsSection.tsx
+++ b/src/components/home/TrendingCarsSection.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 import { ArrowRight } from 'lucide-react';
 // import "./"
 
-const TrendingCars = [
+const trendingCars = [
   { title: 'Chevy', img: Chevy, link: '/car-covers/chevrolet' },
   { title: 'Dodge', img: Dodge, link: '/car-covers/dodge' },
   { title: 'Ford', img: Ford, link: '/car-covers/ford' },
@@ -20,9 +20,9 @@ const TrendingCarsSection = () => {
         trending car brands
       </p>
       <div className="max-w-screen flex gap-[20px] overflow-x-auto">
-        {TrendingCars.map(({ title, img, link }) => (
+        {trendingCars.map(({ title, img, link }, i) => (
           <div
-            key={``}
+            key={`${title}-${i}`}
             className="relative flex min-h-[229px] min-w-[197px] flex-col items-center"
           >
             <a href={link}>

--- a/src/components/icons/ReviewRatingStar.tsx
+++ b/src/components/icons/ReviewRatingStar.tsx
@@ -1,0 +1,31 @@
+import { Rating } from '@mui/material';
+
+type ReviewRatingStarProps = {
+  rating?: number;
+  size?: 'small' | 'medium' | 'large';
+};
+export default function ReviewRatingStar({
+  rating = 5,
+  size = 'large',
+}: ReviewRatingStarProps) {
+  return (
+    <Rating
+      name="read-only"
+      value={rating}
+      readOnly
+      precision={0.5}
+      size={size}
+      sx={{
+        '& .MuiRating-iconFilled': {
+          color: '#FFD80E',
+          stroke: '#FF9F47',
+          strokeWidth: 1,
+        },
+        '& .MuiRating-iconEmpty': {
+          color: '#FF9F47',
+          fill: 'transparent',
+        },
+      }}
+    />
+  );
+}

--- a/src/pages/home/HomepageReviews.tsx
+++ b/src/pages/home/HomepageReviews.tsx
@@ -7,14 +7,14 @@ import {
 } from '@/components/ui/carousel';
 import Image, { StaticImageData } from 'next/image';
 import React, { useCallback, useEffect, useState } from 'react';
-import StarIcon from '@/components/icons/StarIcon';
 import Reviews1 from '@/images/reviews/review2_1.jpg';
 import Reviews2 from '@/images/reviews/review1_1.jpg';
 import Reviews3 from '@/images/reviews/review1_2.jpg';
 import Reviews4 from '@/images/reviews/review1_5.jpg';
+import ReviewRatingStar from '@/components/icons/ReviewRatingStar';
 
 const HomepageReviews = () => {
-  const Reviews = [
+  const reviews = [
     {
       rating: 5,
       img: Reviews1,
@@ -23,7 +23,7 @@ const HomepageReviews = () => {
       owner: 'Henry Green',
     },
     {
-      rating: 4,
+      rating: 5,
       img: Reviews2,
       title: 'Car covers are important for vehicle protection',
       body: "Peace of mind, no worries. It's the perfect accessory for my car that I wouldn't go without this cover surpassed my expectations. Dependable and reliable, year after year.",
@@ -90,7 +90,7 @@ const HomepageReviews = () => {
       <div>
         <Carousel setApi={setApi}>
           <CarouselContent>
-            {Reviews.map((item, index) => (
+            {reviews.map((item, index) => (
               <ReviewsItem key={`carousel-item-${index}`} item={item} />
             ))}
           </CarouselContent>
@@ -116,6 +116,7 @@ type ReviewData = {
   body: string;
   owner: string;
 };
+
 const ReviewsItem = ({ key, item }: { key: string; item: ReviewData }) => (
   <CarouselItem
     key={key}
@@ -135,11 +136,7 @@ const ReviewsItem = ({ key, item }: { key: string; item: ReviewData }) => (
     </div>
     <div className="flex min-h-[390px] flex-col items-center gap-[44px] text-center lg:ml-[142.5px] lg:max-w-[524px] lg:items-start lg:text-left">
       <div className="mb-[-26px] flex">
-        {[...Array(item?.rating)].map((index) => (
-          <div key={`star-${index}`} className="flex flex-col">
-            <StarIcon />
-          </div>
-        ))}
+        <ReviewRatingStar rating={item?.rating} />
       </div>
       <div className="mb-[-10px] w-full  text-[18px] font-[700] lg:text-[26px]">
         {item?.title}


### PR DESCRIPTION
- [x]  Disable links for SUV cover / Truck cover until those pages are ready
- [x]  Make the Best Selling Car model image clickable
    - [x]  Shop Now is a little off center
- [x]  Warranty needs to be updated to lifetime (ref figma)
- [x]  Q&A also updated (ref figma)
- [x] Show 'Only # Left' don't show until they have Make/Model/Year, is ok if they have to select submodel. Truck is going to be weird but should be ok if we're changing soon
- [x] Updated hero drop downs with tab index to make it easier to tab to