### PR TITLE
Added Year Params to Store

### DIFF
--- a/src/app/(main)/[productType]/components/CarPDP.tsx
+++ b/src/app/(main)/[productType]/components/CarPDP.tsx
@@ -42,6 +42,7 @@ interface ICarCoverSelectionState extends ICarCoverProps {
   query: TQuery;
   setReviewData: (newReviewData: TReviewData[]) => void;
   setReviewDataSummary: (newReviewDataSummary: TProductReviewSummary) => void;
+  paramsYear: string;
 }
 
 const createCarSelectionStore = ({
@@ -165,6 +166,7 @@ const createCarSelectionStore = ({
     setReviewDataSummary: (newReviewDataSummary: TProductReviewSummary) => {
       set(() => ({ reviewDataSummary: newReviewDataSummary }));
     },
+    paramsYear: params.year || '',
   }));
 };
 

--- a/src/components/PDP/MobilePDPDetails.tsx
+++ b/src/components/PDP/MobilePDPDetails.tsx
@@ -20,7 +20,6 @@ import { Plus } from 'lucide-react';
 import ProductVideo from './ProductVideo';
 import ThreeSixtyVideo from '@/videos/360 degree_website.mp4';
 import { CarSelectionContext } from '@/app/(main)/[productType]/components/CarPDP';
-import { useStore } from 'zustand';
 
 const CarCoverFeature = ({ children }: { children: string }) => (
   <li className="text-[14px] font-[500] normal-case leading-[26px]">
@@ -31,8 +30,6 @@ const CarCoverFeature = ({ children }: { children: string }) => (
 export const MobilePDPDetails = () => {
   const store = useContext(CarSelectionContext);
   if (!store) throw new Error('Missing CarContext.Provider in the tree');
-  const reviewData = useStore(store, (s) => s.reviewData);
-
   const pdRef = useRef<HTMLDivElement>(null);
   const benRef = useRef<HTMLDivElement>(null);
   const qaRef = useRef<HTMLDivElement>(null);

--- a/src/components/PDP/OtherDetails.tsx
+++ b/src/components/PDP/OtherDetails.tsx
@@ -13,12 +13,10 @@ import ProductVideo from './ProductVideo';
 import ThreeSixtyVideo from '@/videos/360 degree_website.mp4';
 import ReviewSection from './components/ReviewSection';
 import { CarSelectionContext } from '@/app/(main)/[productType]/components/CarPDP';
-import { useStore } from 'zustand';
 
 export function ExtraProductDetails() {
   const store = useContext(CarSelectionContext);
   if (!store) throw new Error('Missing CarContext.Provider in the tree');
-  const reviewData = useStore(store, (s) => s.reviewData);
   // const [selectedSection, setSelectedSection] = useState<string>('');
 
   const benefitsRef = useRef<HTMLDivElement>(null);

--- a/src/components/PDP/components/ReviewSection.tsx
+++ b/src/components/PDP/components/ReviewSection.tsx
@@ -14,16 +14,14 @@ import { AiOutlineLoading3Quarters } from 'react-icons/ai';
 const ReviewSection = () => {
   const store = useContext(CarSelectionContext);
   if (!store) throw new Error('Missing CarContext.Provider in the tree');
-  const selectedProduct = useStore(store, (s) => s.selectedProduct);
   const reviewData = useStore(store, (s) => s.reviewData);
   const setReviewData = useStore(store, (s) => s.setReviewData);
   const { total_reviews, average_score } = useStore(
     store,
     (s) => s.reviewDataSummary
   );
-  const { year, type, make, model } = useStore(store, (s) => s.query);
-  const parentGenerationYear =
-    type && make && model ? selectedProduct.parent_generation : year;
+  const { type, make, model } = useStore(store, (s) => s.query);
+  const year = useStore(store, (s) => s.paramsYear);
   const isMobile = useMediaQuery('(max-width: 768px)');
 
   const [loading, setLoading] = useState(false);
@@ -48,7 +46,7 @@ const ReviewSection = () => {
       const newReviewData = await getProductReviewsByPage(
         {
           productType: typeString,
-          year: parentGenerationYear as string,
+          year,
           make,
           model,
         },
@@ -97,7 +95,7 @@ const ReviewSection = () => {
       const newReviewData = await getProductReviewsByPage(
         {
           productType: typeString,
-          year: parentGenerationYear as string,
+          year,
           make,
           model,
         },
@@ -168,7 +166,7 @@ const ReviewSection = () => {
           ? await getProductReviewsByPage(
               {
                 productType: typeString,
-                year: parentGenerationYear as string,
+                year,
                 make,
                 model,
               },
@@ -186,7 +184,7 @@ const ReviewSection = () => {
           : await getProductReviewsByPage(
               {
                 productType: typeString,
-                year: parentGenerationYear as string,
+                year,
                 make,
                 model,
               },


### PR DESCRIPTION
Forgot to commit this in the last PR.

Added year params to store so it was easier for me to detect what page we were on and if we needed to use the parent generation year for searching.