### PR TITLE
Fixing Multiple Re-rendering which caused Google Tag to fire events multiple times

### DIFF
--- a/src/hooks/useGoogleTagDataLayer.ts
+++ b/src/hooks/useGoogleTagDataLayer.ts
@@ -36,7 +36,7 @@ export const useItemViewedGoogleTag = (
     pathname,
     productName,
     selectedProduct,
-    uniqueColors,
+    // uniqueColors,
   ]);
 };
 


### PR DESCRIPTION
- Removed unique colors from dependency array to make it stop re-rendering multiple times