### PR TITLE
Removed discount from gtag temporarily

### DIFF
--- a/src/hooks/useGoogleTagDataLayer.ts
+++ b/src/hooks/useGoogleTagDataLayer.ts
@@ -50,7 +50,7 @@ export const useItemViewedGoogleTag = (selectedProduct: IProductData) => {
             item_name: productName,
             affiliation: undefined,
             coupon: undefined,
-            discount: isComplete ? discount : undefined,
+            discount: undefined, // Removed temporarily because we transfer the promotional price or something
             index: 0,
             item_brand: 'Coverland',
             item_category: params?.productType,
@@ -88,7 +88,7 @@ export const useCheckoutViewedGoogleTag = () => {
         item_name: productName,
         affiliation: undefined,
         coupon: undefined,
-        discount: discount,
+        discount: undefined, // Removed temporarily because we transfer the promotional price or something
         index: index,
         item_brand: 'Coverland',
         item_category: cartItem.type,
@@ -149,7 +149,7 @@ export const useThankYouViewedGoogleTag = (
             item_name: productName,
             affiliation: undefined,
             coupon: undefined,
-            discount: discount,
+            discount: undefined, // Removed temporarily because we transfer the promotional price or something
             index: index,
             item_brand: 'Coverland',
             item_category: cartItem.type,
@@ -207,7 +207,7 @@ export const handleAddToCartGoogleTag = (
           item_name: productName,
           affiliation: undefined,
           coupon: undefined,
-          discount: discount,
+          discount: undefined, // Removed temporarily because we transfer the promotional price or something
           index: 0,
           item_brand: 'Coverland',
           item_category: params?.productType,


### PR DESCRIPTION
From Calvin:

> From the google ad manager:
> 
> Remove the discount, since we transfer the promotional price, the discount can be considered again. To avoid duplication, you need to remove it.